### PR TITLE
Upgrade to core24 base

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Install the tester Snap
       run: |
-        sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
+        make install
 
     - name: Run Tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,27 +8,19 @@ on:
   # allow running manually
   workflow_dispatch:
 
-env:
-  SNAPCRAFT_BUILD_ENVIRONMENT: lxd
-
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Install Snapcraft
-      run: |
-        sudo snap install snapcraft --classic
-    - name: Setup LXD
-      uses: whywaita/setup-lxd@v1
-      with:
-        lxd_version: latest/stable
+    - name: Build snap
+      uses: snapcore/action-build@v1
+      id: snapcraft
 
-    - name: Build and install the tester Snap
+    - name: Install the tester Snap
       run: |
-        snapcraft
-        sudo snap install ./go-snapctl-tester_test_amd64.snap --dangerous
+        sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
 
     - name: Run Tests
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 *.log
 .idea
 coverage.out
-VERSION
 prime
 squashfs-root
+*.snap

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,16 @@
 build:
-	snapcraft
+	snapcraft -v
+
+clean-build:
+	snapcraft clean
+	make build
 
 install:
 	sudo snap install --dangerous ./go-snapctl-tester_test_amd64.snap
-
-# This was meant to be used to sync the prime directory with the source code in snapcraft try mode.
-# It can't be used that way because snapcraft try doesn't work with core24.
-# To make this method work, the test files should be kepts in a writable directory and copied over.
-# sync:
-# 	cp -r $$(ls | egrep -v '^prime') prime/
+	sudo snap connect go-snapctl-tester:home
 
 test:
-	sudo go-snapctl-tester.test \
-		./ \
-		./log \
-		./env
+	sudo go-snapctl-tester.test ./...
+
+remove:
+	sudo snap remove go-snapctl-tester

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
+build:
+	snapcraft
 
-try:
-	snapcraft try --use-lxd
-	snap try prime
+install:
+	sudo snap install --dangerous ./go-snapctl-tester_test_amd64.snap
 
-sync:
-	cp -r $$(ls | egrep -v '^prime') prime/
+# This was meant to be used to sync the prime directory with the source code in snapcraft try mode.
+# It can't be used that way because snapcraft try doesn't work with core24.
+# To make this method work, the test files should be kepts in a writable directory and copied over.
+# sync:
+# 	cp -r $$(ls | egrep -v '^prime') prime/
 
 test:
 	sudo go-snapctl-tester.test \
 		./ \
 		./log \
-		./snapctl \
 		./env

--- a/README.md
+++ b/README.md
@@ -103,25 +103,28 @@ func main() {
 ### Testing
 The tests need to run in a snap environment:
 
-Build and install:
+Build and install the tester snap:
 ```bash
-make build
-make install
+make build # or clean-build
+make install 
 ```
-
-The tests files are read relative to project source inside the snap.
-The `go-snapctl-tester.test` command runs `go test -v --cover` internally and accepts
-all other go test arguments.
 
 Run all tests:
-```
+```bash
 make test
 ```
 
-Run top-level tests:
+The above runs the all the tests with sudo, required to test privileged operations such as `snapctl set`.
+
+To manually run tests, use: 
 ```bash
 sudo go-snapctl-tester.test
 ```
+
+This app copies the project files to a writable data location inside the snap.
+This is to allow running tests (which required file locking) that are in the user's home via the root user.
+
+The `test` app accepts `go test` and `go vet` flags, appended to the end of the command.
 
 Run tests in one package, e.g. `log`:
 ```bash

--- a/README.md
+++ b/README.md
@@ -124,14 +124,9 @@ sudo go-snapctl-tester.test
 This app copies the project files to a writable data location inside the snap.
 This is to allow running tests (which required file locking) that are in the user's home via the root user.
 
-The `test` app accepts `go test` and `go vet` flags, appended to the end of the command.
+The `test` app accepts arguments that are supported by both `go test` and `go vet`, appended to the end of the commands.
 
-Run tests in one package, e.g. `log`:
+For example, to run tests in one package, i.e. `log`:
 ```bash
 sudo go-snapctl-tester.test ./log
-```
-
-Run one unit test, e.g. `TestGet`:
-```bash
-sudo go-snapctl-tester.test ./log -run TestSetComponentName
 ```

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ The tests need to run in a snap environment:
 
 Build and install:
 ```bash
-snapcraft
-sudo snap install --dangerous ./go-snapctl-tester_test_amd64.snap
+make build
+make install
 ```
 
 The tests files are read relative to project source inside the snap.
@@ -123,25 +123,12 @@ Run top-level tests:
 sudo go-snapctl-tester.test
 ```
 
-Run tests in one package, e.g. `snapctl`:
+Run tests in one package, e.g. `log`:
 ```bash
-sudo go-snapctl-tester.test ./snapctl
+sudo go-snapctl-tester.test ./log
 ```
 
 Run one unit test, e.g. `TestGet`:
 ```bash
-sudo go-snapctl-tester.test ./snapctl -run TestGet
-```
-
-#### Development
-```
-make try
-```
-
-You can now edit the files locally, copy them to prime directory, and re-run the
-tests without rebuilding the project. E.g.:
-
-```
-make sync
-sudo go-snapctl-tester.test ./snapctl
+sudo go-snapctl-tester.test ./log -run TestSetComponentName
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/canonical/go-snapctl/snapctl"
+	"github.com/canonical/go-snapctl"
 )
 
 func main() {

--- a/snap/local/bin/test.sh
+++ b/snap/local/bin/test.sh
@@ -2,13 +2,18 @@
 
 set -e
 
-echo "Running tests from $0"
+echo "Running tests via $0"
 
 # setup the environment
 export PATH=$PATH:$SNAP/go/bin
 export CGO_ENABLED=0
-echo "Change directory to $SNAP"
-cd $SNAP
+
+echo "Copying project files to $SNAP_COMMON"
+cp -r ./* $SNAP_COMMON
+
+cd $SNAP_COMMON
+
+echo "Running tests in $SNAP_COMMON"
 
 go test -p 1 --cover "$@"
 echo "✅ go test"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,16 +12,19 @@ plugs:
   test-plug:
     interface: content
     target: $SNAP_DATA
+  
+  home:
+    read: all # to access tests located in some home directory with root user
 
 apps:
   # App for running the tests
   test:
-    command: snap/local/bin/test.sh
+    command: bin/test.sh
     plugs: [network, home]
 
   # Mocked apps needed for testing
   mock-service: &ms
-    command: snap/local/bin/mock-app.sh
+    command: bin/mock-app.sh
     daemon: simple
     install-mode: disable
   mock-service-2: *ms
@@ -36,11 +39,10 @@ parts:
     # organize:
     #   '*': go/
     plugin: dump
-    source: https://go.dev/dl/go1.17.6.linux-amd64.tar.gz
+    source: https://go.dev/dl/go1.24.0.linux-amd64.tar.gz
     organize:
       "*": go/
 
-  # maintain test and binary files structure to simplify test development
-  tests:
+  bin:
     plugin: dump
-    source: .
+    source: snap/local

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,8 +1,8 @@
 name: go-snapctl-tester
-base: core20
+base: core24
 version: test
 summary: Tester for go-snapctl
-description: This snap is used to run tests on this package
+description: This snap is used to run the tests inside the snap environment.
 
 grade: devel
 confinement: strict


### PR DESCRIPTION
- Upgrade base from core20 to core24
- Change testing workflow to use project files, instead of packaging test files

```console
$ make test
sudo go-snapctl-tester.test ./...
Running tests via /snap/go-snapctl-tester/x1/bin/test.sh
Copying project files to /var/snap/go-snapctl-tester/common
Running tests in /var/snap/go-snapctl-tester/common
go: downloading github.com/stretchr/testify v1.8.4
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.1
ok      github.com/canonical/go-snapctl 13.552s coverage: 88.2% of statements
ok      github.com/canonical/go-snapctl/env     0.007s  coverage: 63.6% of statements
ok      github.com/canonical/go-snapctl/log     0.083s  coverage: 43.6% of statements
✅ go test
✅ go vet
```