### PR TITLE
Init snap only if used from a snap

### DIFF
--- a/env/init.go
+++ b/env/init.go
@@ -1,0 +1,16 @@
+//go:build !nosnap
+
+package env
+
+import (
+	"os"
+
+	"github.com/canonical/go-snapctl/log"
+)
+
+func init() {
+	if err := getEnvVars(); err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+}

--- a/env/snapvars.go
+++ b/env/snapvars.go
@@ -46,9 +46,9 @@ const (
 	snapRevEnv      = "SNAP_REVISION"
 )
 
-// loadSnapEnv populates global variables for each of the SNAP*
+// getEnvVars populates global variables for each of the SNAP*
 // variables defined in the snap's environment
-func loadSnapEnv() error {
+func getEnvVars() error {
 	Snap = os.Getenv(snapEnv)
 	if Snap == "" {
 		return errors.New("SNAP is not set")
@@ -83,10 +83,8 @@ func loadSnapEnv() error {
 }
 
 func init() {
-	if _, snap := os.LookupEnv("SNAP"); snap {
-		if err := loadSnapEnv(); err != nil {
-			log.Error(err)
-			os.Exit(1)
-		}
+	if err := getEnvVars(); err != nil {
+		log.Error(err)
+		os.Exit(1)
 	}
 }

--- a/env/snapvars.go
+++ b/env/snapvars.go
@@ -18,8 +18,6 @@ package env
 import (
 	"errors"
 	"os"
-
-	"github.com/canonical/go-snapctl/log"
 )
 
 var (
@@ -80,11 +78,4 @@ func getEnvVars() error {
 	}
 
 	return nil
-}
-
-func init() {
-	if err := getEnvVars(); err != nil {
-		log.Error(err)
-		os.Exit(1)
-	}
 }

--- a/env/snapvars.go
+++ b/env/snapvars.go
@@ -46,9 +46,9 @@ const (
 	snapRevEnv      = "SNAP_REVISION"
 )
 
-// getEnvVars populates global variables for each of the SNAP*
+// loadSnapEnv populates global variables for each of the SNAP*
 // variables defined in the snap's environment
-func getEnvVars() error {
+func loadSnapEnv() error {
 	Snap = os.Getenv(snapEnv)
 	if Snap == "" {
 		return errors.New("SNAP is not set")
@@ -83,8 +83,10 @@ func getEnvVars() error {
 }
 
 func init() {
-	if err := getEnvVars(); err != nil {
-		log.Error(err)
-		os.Exit(1)
+	if _, snap := os.LookupEnv("SNAP"); snap {
+		if err := loadSnapEnv(); err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
 	}
 }

--- a/env/snapvars_test.go
+++ b/env/snapvars_test.go
@@ -32,7 +32,7 @@ func TestEnvVars(t *testing.T) {
 	os.Setenv(snapRevEnv, "2112")
 
 	// Test
-	err := loadSnapEnv()
+	err := getEnvVars()
 
 	// Assert values
 	assert.Nil(t, err)

--- a/env/snapvars_test.go
+++ b/env/snapvars_test.go
@@ -32,7 +32,7 @@ func TestEnvVars(t *testing.T) {
 	os.Setenv(snapRevEnv, "2112")
 
 	// Test
-	err := getEnvVars()
+	err := loadSnapEnv()
 
 	// Assert values
 	assert.Nil(t, err)

--- a/log/init.go
+++ b/log/init.go
@@ -13,12 +13,10 @@ var (
 )
 
 func init() {
-	if _, snap := os.LookupEnv("SNAP"); snap {
-		InitSnap()
-	}
+	Init()
 }
 
-func InitSnap() {
+func Init() {
 	value, err := exec.Command("snapctl", "get", "debug").CombinedOutput()
 	if err != nil {
 		stderr(err)

--- a/log/init.go
+++ b/log/init.go
@@ -13,10 +13,12 @@ var (
 )
 
 func init() {
-	Init()
+	if _, snap := os.LookupEnv("SNAP"); snap {
+		InitSnap()
+	}
 }
 
-func Init() {
+func InitSnap() {
 	value, err := exec.Command("snapctl", "get", "debug").CombinedOutput()
 	if err != nil {
 		stderr(err)

--- a/log/init.go
+++ b/log/init.go
@@ -1,3 +1,5 @@
+//go:build !nosnap
+
 package log
 
 import (
@@ -6,17 +8,11 @@ import (
 	"os/exec"
 )
 
-var (
-	debug           bool
-	snapInstanceKey string // used as default syslog tag and tag prefix
-	tag             string // syslog tag and stderr prefix
-)
-
 func init() {
-	Init()
+	initLogger()
 }
 
-func Init() {
+func initLogger() {
 	value, err := exec.Command("snapctl", "get", "debug").CombinedOutput()
 	if err != nil {
 		stderr(err)

--- a/log/init_test.go
+++ b/log/init_test.go
@@ -33,13 +33,13 @@ func TestInitialize(t *testing.T) {
 		// set it to true and check
 		output, err := exec.Command("snapctl", "set", "debug=true").CombinedOutput()
 		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
-		InitSnap()
+		Init()
 		require.True(t, debug)
 
 		// unset and re-check
 		output, err = exec.Command("snapctl", "unset", "debug").CombinedOutput()
 		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
-		InitSnap()
+		Init()
 		require.False(t, debug)
 	})
 

--- a/log/init_test.go
+++ b/log/init_test.go
@@ -33,13 +33,13 @@ func TestInitialize(t *testing.T) {
 		// set it to true and check
 		output, err := exec.Command("snapctl", "set", "debug=true").CombinedOutput()
 		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
-		Init()
+		InitSnap()
 		require.True(t, debug)
 
 		// unset and re-check
 		output, err = exec.Command("snapctl", "unset", "debug").CombinedOutput()
 		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
-		Init()
+		InitSnap()
 		require.False(t, debug)
 	})
 

--- a/log/init_test.go
+++ b/log/init_test.go
@@ -33,13 +33,13 @@ func TestInitialize(t *testing.T) {
 		// set it to true and check
 		output, err := exec.Command("snapctl", "set", "debug=true").CombinedOutput()
 		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
-		Init()
+		initLogger()
 		require.True(t, debug)
 
 		// unset and re-check
 		output, err = exec.Command("snapctl", "unset", "debug").CombinedOutput()
 		assert.NoError(t, err, "Error setting config value via snapctl: %s", output)
-		Init()
+		initLogger()
 		require.False(t, debug)
 	})
 

--- a/log/log.go
+++ b/log/log.go
@@ -22,7 +22,12 @@ import (
 	"os"
 )
 
-var slog *syslog.Writer
+var (
+	debug           bool   // set via snap option
+	snapInstanceKey string // used as default syslog tag and tag prefix
+	tag             string // syslog tag and stderr prefix
+	slog            *syslog.Writer
+)
 
 // SetComponentName adds a component name to syslog tag as "snap.<snap-instance-name>.<component>"
 // The default tag is just "snap.<snap-instance-name>".


### PR DESCRIPTION
The package is meant to be used from an application that runs from inside a snap. It is currently not possible to import this package and use it from a binary that is meant to run also from outside the snap, e.g. for testing. This is because the init functions exit with non-zero code when they fail to load snap variables or run snapctl. 

This change makes the init functions conditional. However, attempting to use the methods from outside a snap will result in unexpected behavior.