### PR TITLE
Implement remove command wrapper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Wrappers for the following subcommands are partially implemented:
 - [ ] `system-mode`: Get the current system mode and associated details
 - [x] `unset`: Remove configuration options
 - [x] `install`: Install a snap component
+- [x] `remove`: Remove a snap component
 
 The commands and descriptions are from `snapctl --help`.
 

--- a/remove-components.go
+++ b/remove-components.go
@@ -1,0 +1,72 @@
+/*
+Usage:
+  snapctl [OPTIONS] remove <snap|snap+comp|+comp>...
+
+The remove command removes components.
+
+
+Help Options:
+  -h, --help                        Show this help message
+
+[remove command arguments]
+  <snap|snap+comp|+comp>:           Components to be removed (snap must be
+                                    the caller snap if specified).
+*/
+
+package snapctl
+
+import (
+	"fmt"
+	"strings"
+)
+
+type removeComponents struct {
+	components []string
+	validators []func() error
+}
+
+// RemoveComponents removes components of the snap
+// It takes an arbitrary number of component names as input
+// It returns an object for setting the CLI arguments before running the command
+func RemoveComponents(components ...string) (cmd removeComponents) {
+	cmd.components = append(cmd.components, components...)
+
+	cmd.validators = append(cmd.validators, func() error {
+		if len(cmd.components) == 0 {
+			return fmt.Errorf("at least one component must be specified")
+		}
+		return nil
+	})
+
+	cmd.validators = append(cmd.validators, func() error {
+		for _, component := range cmd.components {
+			if strings.Contains(component, " ") {
+				return fmt.Errorf("component names must not contain spaces. Got: '%s'", component)
+			}
+		}
+		return nil
+	})
+
+	return cmd
+}
+
+// Run executes the remove command
+func (cmd removeComponents) Run() error {
+	// validate all input
+	for _, validate := range cmd.validators {
+		if err := validate(); err != nil {
+			return err
+		}
+	}
+
+	// construct the command args
+	// remove [remove-OPTIONS] <snap|snap+comp|+comp>... - we only support <+comp>... for now
+	var args []string
+
+	for _, component := range cmd.components {
+		args = append(args, "+"+component)
+	}
+
+	_, err := run("remove", args...)
+	return err
+}

--- a/remove-components_test.go
+++ b/remove-components_test.go
@@ -1,0 +1,34 @@
+package snapctl_test
+
+import (
+	"testing"
+
+	"github.com/canonical/go-snapctl"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+TestInstall runs `snapctl install` to do a smoke test of this function.
+It is only possible to do a real component installation for a snap that is in the snap store.
+*/
+func TestRemove(t *testing.T) {
+	t.Run("snapctl remove +valid-name", func(t *testing.T) {
+		err := snapctl.RemoveComponents("valid-name").Run()
+		require.ErrorContainsf(t, err, "component \"valid-name\" is not installed for revision", "Unexpected error returned")
+	})
+
+	t.Run("snapctl remove +one +two +three", func(t *testing.T) {
+		err := snapctl.RemoveComponents("one", "two", "three").Run()
+		require.ErrorContainsf(t, err, "component \"one\" is not installed for revision", "Unexpected error returned")
+	})
+
+	t.Run("snapctl remove +invalid name", func(t *testing.T) {
+		err := snapctl.RemoveComponents("invalid name").Run()
+		require.ErrorContainsf(t, err, "component names must not contain spaces", "Unexpected error returned")
+	})
+
+	t.Run("snapctl remove +<no name>", func(t *testing.T) {
+		err := snapctl.RemoveComponents().Run()
+		require.ErrorContainsf(t, err, "at least one component must be specified", "Unexpected error returned")
+	})
+}

--- a/remove-components_test.go
+++ b/remove-components_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 /*
-TestInstall runs `snapctl install` to do a smoke test of this function.
-It is only possible to do a real component installation for a snap that is in the snap store.
+TestRemove smoke tests the component removal.
+It is only possible to do a real component removal for a snap that is in the snap store.
 */
 func TestRemove(t *testing.T) {
 	t.Run("snapctl remove +valid-name", func(t *testing.T) {


### PR DESCRIPTION
Required for `prune-cache` command
Corresponding PR in [inference-snap-cli](https://github.com/canonical/inference-snaps-cli/pull/277)