### PR TITLE
Add getter for snap version

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -27,6 +27,7 @@ const (
 	snapInstNameEnv = "SNAP_INSTANCE_NAME"
 	snapNameEnv     = "SNAP_NAME"
 	snapRevEnv      = "SNAP_REVISION"
+	snapVersionEnv  = "SNAP_VERSION"
 )
 
 // Getter functions for SNAP environment variables.
@@ -53,4 +54,8 @@ func SnapName() string {
 
 func SnapRevision() string {
 	return os.Getenv(snapRevEnv)
+}
+
+func SnapVersion() string {
+	return os.Getenv(snapVersionEnv)
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -35,4 +35,6 @@ func TestEnvVars(t *testing.T) {
 	assert.Equal(t, "go-snapctl-tester", SnapName())
 	// SNAP_REVISION
 	assert.Regexp(t, "x\\d+", SnapRevision())
+	// SNAP_VERSION
+	assert.Equal(t, "test", SnapVersion())
 }


### PR DESCRIPTION
This PR adds `env.SnapVersion()`, a getter for the snap's current version, obtained by reading the `SNAP_VERSION` environment variable